### PR TITLE
Changed parameter values from `ow_meta` to correct idenfiers.

### DIFF
--- a/Sources/Utilities/Actions/ApiAction.swift
+++ b/Sources/Utilities/Actions/ApiAction.swift
@@ -64,14 +64,14 @@ public class ApiAction {
         
         requestArgs = args
         
-        if let method = args["__ow_meta_verb"] as? String {
+        if let method = args["__ow_method"] as? String {
             requestMethod = HTTPMethod(rawValue: method) ?? .unknown
         }
         else {
-            log("__ow_meta_verb is not set")
+            log("__ow_method is not set")
             requestMethod = .unknown
         }
-        requestHeaders = args["__ow_meta_headers"] as? [String : String] ?? [:]
+        requestHeaders = args["__ow_headers"] as? [String : String] ?? [:]
         
         //  Default response is success with empty JSON
         responseJSON = [:]
@@ -89,7 +89,7 @@ public class ApiAction {
             return
         }
         
-        let result: [String : Any] = [ "body": base64_body, "code": responseCode, "headers": responseHeaders ]
+        let result: [String : Any] = [ "body": base64_body, "statusCode": responseCode, "headers": responseHeaders ]
         if let respString = JSONUtils.dictionaryToJsonString(jsonDict: result) {
             print("\(respString)")
         } else {
@@ -127,7 +127,7 @@ public extension ApiAction {
     ///
     /// - Returns: true if check passed, and false otherwise
     public func checkClientId() -> Bool {
-        guard let cliendId = requestHeaders["X-Client-Id"],
+        guard let cliendId = requestHeaders["x-client-id"],
             cliendId == ApiAction.ClientId else {
             makeErrorResponse(ApiAction.Error.clientIdMissing)
             return false


### PR DESCRIPTION
I found three tiny issues due to outdated documentation in Rob's blog post.

- `__ow_meta_verb` has been renamed to `__ow_method`
- `__ow_meta_headers` has been renamed to `__ow_headers`
- Headers from client request are converted to lowercase by platform.`X-Client-Id` -> `x-client-id`

Invoking this web action with the correct header return the unix time values.

```
$ http get https://openwhisk.ng.bluemix.net/api/v1/web/james.thomas@uk.ibm.com_dev/default/swift-packages-dev-time X-Client-Id:SOME
_CLIENT_ID
HTTP/1.1 200 OK
Access-Control-Allow-Headers: Authorization, Content-Type
Access-Control-Allow-Methods: OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH
Access-Control-Allow-Origin: *
Connection: Keep-Alive
Content-Type: application/json
Date: Thu, 25 Jan 2018 17:38:19 GMT
IBM_Cloud_Functions: OpenWhisk
Server: nginx/1.11.13
Set-Cookie: DPJSESSIONID=PBC5YS:-2098699314; Path=/; Domain=.whisk.ng.bluemix.net
Transfer-Encoding: chunked
X-Backside-Transport: OK OK
X-Global-Transaction-ID: 1041013407

{
    "unixtime": "1516901899"
}
```

If I am missing the client header, it returns the 401.

```
$ http get https://openwhisk.ng.bluemix.net/api/v1/web/james.thomas@uk.ibm.com_dev/default/swift-packages-dev-time
HTTP/1.1 401 Unauthorized
Access-Control-Allow-Headers: Authorization, Content-Type
Access-Control-Allow-Methods: OPTIONS, GET, DELETE, POST, PUT, HEAD, PATCH
Access-Control-Allow-Origin: *
Connection: Keep-Alive
Content-Type: application/json
Date: Thu, 25 Jan 2018 17:39:45 GMT
IBM_Cloud_Functions: OpenWhisk
Server: nginx/1.11.13
Set-Cookie: DPJSESSIONID=PBC5YS:1376290542; Path=/; Domain=.whisk.ng.bluemix.net
Transfer-Encoding: chunked
X-Backside-Transport: FAIL FAIL
X-Global-Transaction-ID: 1503782439

{
    "error": "Client Id is missing or wrong"
}
```